### PR TITLE
fix: Add infoprops options for accordion storybook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ docs/src/exampleMenus
 docs/dist/
 .jest-test-results.json
 storybook-static
+.out
 
 # misc
 .DS_Store

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "prepublishOnly": "npm run build",
     "start": "npm run storybook",
     "storybook": "start-storybook -p 6006",
+    "build-storybook": "build-storybook -c .storybook -o .out",
     "deploy-storybook": "storybook-to-ghpages --remote=storybook --branch=master --output-dir=../storybook-temp"
   },
   "author": "Hugo Nogueira <hugomn@gmail.com>",

--- a/src/components/Transition/index.js
+++ b/src/components/Transition/index.js
@@ -5,4 +5,6 @@ const Transition = props => {
   return <SUIRTransition {...props} />;
 };
 
+Transition.displayName = "Transition";
+
 export default Transition;

--- a/stories/Accordion/index.stories.js
+++ b/stories/Accordion/index.stories.js
@@ -1,23 +1,26 @@
-import React from "react";
-import { storiesOf } from "@storybook/react";
-import { Accordion } from "../../src/components";
-import { Icon } from "@infinitecsolutions/semantic-ui-react";
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { Accordion } from '../../src/components';
+import { Icon } from '@infinitecsolutions/semantic-ui-react';
 
 const stories = storiesOf(Accordion.displayName, module);
 
-stories.addWithAddons(Accordion, () => {
-  return  (<Accordion>
-    <Accordion.Title active={false} >
-      <Icon name='dropdown' />
-      How do you acquire a dog?
-    </Accordion.Title>
+stories.addWithAddons(
+  Accordion,
+  () => {
+    return  (
+      <Accordion>
+        <Accordion.Title active>
+          <Icon name='dropdown' />
+          What is a dog?
+        </Accordion.Title>
         <Accordion.Content active>
           <p>
             A dog is a type of domesticated animal. Known for its loyalty and faithfulness, it can
             be found as a welcome guest in many households across the world.
           </p>
         </Accordion.Content>
-        <Accordion.Title active={false} >
+        <Accordion.Title active={false}>
           <Icon name='dropdown' />
           How do you acquire a dog?
         </Accordion.Title>
@@ -30,4 +33,10 @@ stories.addWithAddons(Accordion, () => {
         </Accordion.Content>
       </Accordion>
     );
-});
+  },
+  {
+    infoProps: {
+      propTablesExclude: [Accordion.Title, Accordion.Content, Icon],
+    },
+  }
+);


### PR DESCRIPTION
Added infoprops for accordion storybook to fix build
and deplot. Also added a npm script to build storybook
locally to validate potential problems in builds.

![carbon](https://user-images.githubusercontent.com/540130/43137208-7dfbbb9c-8f4b-11e8-9fb2-49384a2ac3a1.png)
