### PR TITLE
feat: Add missing proptype name for Icon component

### DIFF
--- a/src/components/Icon/index.js
+++ b/src/components/Icon/index.js
@@ -51,6 +51,9 @@ Icon.propTypes = {
   /** Icon can be used as a simple loader. */
   loading: PropTypes.bool,
 
+  /** Name of the icon. */
+  name: PropTypes.string,
+
   /** Icon can rotated. */
   rotated: PropTypes.oneOf(["clockwise", "counterclockwise"]),
 


### PR DESCRIPTION
Added a string PropType for Icon component so that
it shows up in documentation in props because it
happens to be most important prop for the component.